### PR TITLE
Update SongsSection header text styling and layout

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -32,7 +32,7 @@ const ContactSection = () => {
       <div className="container mx-auto px-4">
         <div className="text-center mb-12">
           <h2 className="font-oswald text-4xl md:text-5xl font-bold text-gwb-white mb-4">
-            <span className="text-gwb-black text-lime-400">KONTAKTAI</span>
+            <span style={{ color: "#7ED321" }}>KONTAKTAI</span>
           </h2>
           <p className="text-gwb-white text-lg max-w-2xl mx-auto">
             Turite klausimų? Norite prisijungti? Susisiekite su mumis!

--- a/src/components/SongsSection.tsx
+++ b/src/components/SongsSection.tsx
@@ -41,9 +41,16 @@ const SongsSection = () => {
       <div className="container mx-auto px-4">
         <div className="text-center mb-12">
           <h2 className="font-oswald text-4xl md:text-5xl font-bold text-gwb-white mb-4">
-            FANŲ{" "}
+            <span>
+              <p>
+                FANŲ{" "}
+                <span style={{ color: "rgb(126, 211, 33)" }}>SKANDUOTĖS</span>
+              </p>
+            </span>
             <span className="text-lime-400">
-              {language === "LT" ? "SKANDUOTĖS" : "CHANTS"}
+              <p>
+                <br />
+              </p>
             </span>
           </h2>
           <p className="text-gwb-white text-lg max-w-2xl mx-auto">


### PR DESCRIPTION
Updates the header text structure in SongsSection component:

- Wraps "FANŲ" text in span and paragraph elements
- Adds inline green color styling (rgb(126, 211, 33)) to "SKANDUOTĖS" text
- Replaces conditional language text with line break in lime-400 span
- Changes from dynamic language-based text to static Lithuanian text with styling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89b38eddd6ed43e9b56d9a33fbc506e7/curry-nest)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89b38eddd6ed43e9b56d9a33fbc506e7</projectId>-->
<!--<branchName>curry-nest</branchName>-->